### PR TITLE
Fixes #16 - Adding transparency support

### DIFF
--- a/example/complete/properties/color/background.json
+++ b/example/complete/properties/color/background.json
@@ -24,6 +24,11 @@
           "disabled": { "value": "{color.brand.secondary.light.value}" },
           "active":   { "value": "{color.brand.secondary.dark.value}" }
         }
+      },
+
+      "overlay": {
+        "light": { "value": "#FFFFFFCC" },
+        "dark":  { "value": "#00000044" }
       }
     }
   }

--- a/lib/common/transformGroups.js
+++ b/lib/common/transformGroups.js
@@ -15,7 +15,8 @@ module.exports = {
   'web': [
     'attribute/cti',
     'name/cti/kebab',
-    'size/px'
+    'size/px',
+    'color/rgb'
   ],
   'scss': [
     'attribute/cti',
@@ -23,7 +24,7 @@ module.exports = {
     'time/seconds',
     'content/icon',
     'size/rem',
-    'color/hex'
+    'color/rgb'
   ],
   'html': [
     'attribute/cti',
@@ -33,7 +34,7 @@ module.exports = {
   'android': [
     'attribute/cti',
     'name/cti/snake',
-    'color/hex',
+    'color/hex8android',
     'size/remToSp',
     'size/remToDp'
   ],

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -139,12 +139,24 @@ module.exports = {
     }
   },
 
-
+  // #rrggbbaa
   'color/hex8': {
     type: 'value',
     matcher: isColor,
     transformer: function (prop) {
       return Color(prop.value).toHex8String();
+    }
+  },
+
+  // #aarrggbb
+  // Android puts the alpha channel first, which is
+  // not the standard
+  'color/hex8android': {
+    type: 'value',
+    matcher: isColor,
+    transformer: function (prop) {
+      var str = Color(prop.value).toHex8();
+      return '#' + str.slice(6) + str.slice(0,6);
     }
   },
 
@@ -175,7 +187,6 @@ module.exports = {
       return parseFloat(prop.value, 10).toFixed(2) + 'dp';
     }
   },
-
 
   'size/remToSp': {
     type: 'value',

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-var Color           = require('color'),
+var Color           = require('tinycolor2'),
     _               = require('lodash'),
     path            = require('path'),
     convertToBase64 = require('../utils/convertToBase64'),
@@ -25,29 +25,34 @@ function isSize(prop) {
   return prop.attributes.category === 'size';
 }
 
+function isFontSize(prop) {
+  return prop.attributes.category === 'size' &&
+    (prop.attributes.type === 'font' || prop.attributes.type === 'icon');
+}
+
+function isNotFontSize(prop) {
+  return prop.attributes.category === 'size' &&
+    prop.attributes.type !== 'font' &&
+    prop.attributes.type !== 'icon';
+}
+
 module.exports = {
   'attribute/color': {
     type: 'attribute',
-    matcher: function (prop) {
-      return prop.attributes.category === 'color' && prop.value.indexOf('{') < 0;
-    },
+    matcher: isColor,
     transformer: function (prop) {
       var color = Color(prop.value);
       return {
-        hex: color.hexString(),
-        rgb: color.rgbString(),
-        hsl: color.hslString(),
-        hsv: color.hwbString(),
-        red: color.red(),
-        blue: color.blue(),
-        green: color.green()
+        hex: color.toHex(),
+        rgb: color.toRgb(),
+        hsl: color.toHsl(),
+        hsv: color.toHsv()
       };
     }
   },
 
   'attribute/cti': {
     type: 'attribute',
-    matcher: function() { return true; },
     transformer: function(prop) {
       return {
         category: prop.path[0],
@@ -122,15 +127,7 @@ module.exports = {
     type: 'value',
     matcher: isColor,
     transformer: function (prop) {
-      return Color(prop.original.value).rgbString();
-    }
-  },
-
-  'color/rgb_array': {
-    type: 'value',
-    matcher: isColor,
-    transformer: function (prop) {
-      return Color(prop.original.value).rgbArray();
+      return Color(prop.value).toRgbString();
     }
   },
 
@@ -138,7 +135,16 @@ module.exports = {
     type: 'value',
     matcher: isColor,
     transformer: function (prop) {
-      return Color(prop.original.value).hexString();
+      return Color(prop.value).toHexString();
+    }
+  },
+
+
+  'color/hex8': {
+    type: 'value',
+    matcher: isColor,
+    transformer: function (prop) {
+      return Color(prop.value).toHex8String();
     }
   },
 
@@ -146,68 +152,52 @@ module.exports = {
     type: 'value',
     matcher: isColor,
     transformer: function (prop) {
-      var rgb = Color(prop.original.value).rgbArray();
-      return '[UIColor colorWithRed:' + (rgb[0]/255).toFixed(2) + 'f' +
-             ' green:' + (rgb[1]/255).toFixed(2) + 'f' +
-             ' blue:' + (rgb[2]/255).toFixed(2) + 'f' +
-             ' alpha:1.0f]';
+      var rgb = Color(prop.value).toRgb();
+      return '[UIColor colorWithRed:' + (rgb.r/255).toFixed(2) + 'f' +
+             ' green:' + (rgb.g/255).toFixed(2) + 'f' +
+             ' blue:' + (rgb.b/255).toFixed(2) + 'f' +
+             ' alpha:' + rgb.a.toFixed(2) + 'f]';
     }
   },
 
   'size/sp': {
     type: 'value',
-    matcher: function(prop) {
-      return prop.attributes.category === 'size' &&
-            (prop.attributes.type === 'font' || prop.attributes.type === 'icon');
-    },
+    matcher: isFontSize,
     transformer: function(prop) {
-      return parseFloat(prop.original.value, 10) + 'sp';
+      return parseFloat(prop.value, 10).toFixed(2) + 'sp';
     }
   },
 
   'size/dp': {
     type: 'value',
-    matcher: function(prop) {
-      return prop.attributes.category === 'size' &&
-             prop.attributes.type !== 'font' &&
-             prop.attributes.type !== 'icon';
-    },
+    matcher: isNotFontSize,
     transformer: function(prop) {
-      return parseFloat(prop.original.value, 10) + 'dp';
+      return parseFloat(prop.value, 10).toFixed(2) + 'dp';
     }
   },
 
 
   'size/remToSp': {
     type: 'value',
-    matcher: function(prop) {
-      return prop.attributes.category === 'size' &&
-            (prop.attributes.type === 'font' || prop.attributes.type === 'icon');
-    },
+    matcher: isFontSize,
     transformer: function(prop) {
-      return (parseFloat(prop.original.value, 10) * 16).toFixed(2) + 'sp';
+      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'sp';
     }
   },
 
   'size/remToDp': {
     type: 'value',
-    matcher: function(prop) {
-      return prop.attributes.category === 'size' &&
-             prop.attributes.type !== 'font' &&
-             prop.attributes.type !== 'icon';
-    },
+    matcher: isNotFontSize,
     transformer: function(prop) {
-      return (parseFloat(prop.original.value, 10) * 16).toFixed(2) + 'dp';
+      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'dp';
     }
   },
 
   'size/px': {
     type: 'value',
-    matcher: function(prop) {
-      return prop.attributes.category === 'size';
-    },
+    matcher: isSize,
     transformer: function(prop) {
-      return parseFloat(prop.original.value, 10) + 'px';
+      return parseFloat(prop.value, 10) + 'px';
     }
   },
 
@@ -215,7 +205,7 @@ module.exports = {
     type: 'value',
     matcher: isSize,
     transformer: function(prop) {
-      return parseFloat(prop.original.value, 10) + 'rem';
+      return parseFloat(prop.value, 10) + 'rem';
     }
   },
 
@@ -223,7 +213,7 @@ module.exports = {
     type: 'value',
     matcher: isSize,
     transformer: function(prop) {
-      return (parseFloat(prop.original.value, 10) * 16).toFixed(2) + 'f';
+      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'f';
     }
   },
 
@@ -231,7 +221,7 @@ module.exports = {
     type: 'value',
     matcher: isSize,
     transformer: function(prop) {
-      return (parseFloat(prop.original.value, 10) * 16).toFixed(0) + 'px';
+      return (parseFloat(prop.value, 10) * 16).toFixed(0) + 'px';
     }
   },
 
@@ -241,8 +231,8 @@ module.exports = {
       return prop.attributes.category === 'content' && prop.attributes.type === 'icon';
     },
     transformer: function (prop) {
-      return prop.original.value.replace(UNICODE_PATTERN, function (match, variable) {
-        return '\'\\' + variable + '\'';
+      return prop.value.replace(UNICODE_PATTERN, function (match, variable) {
+        return "'\\" + variable + "'";
       });
     }
   },
@@ -283,7 +273,7 @@ module.exports = {
       return prop.attributes.category === 'time';
     },
     transformer: function(prop) {
-      return (parseInt(prop.original.value) / 1000).toString() + 's';
+      return (parseFloat(prop.value) / 1000).toFixed(2) + 's';
     }
   },
 
@@ -305,7 +295,7 @@ module.exports = {
       return prop.attributes.category === 'asset';
     },
     transformer: function(prop) {
-      return path.join(process.cwd(), prop.original.value);
+      return path.join(process.cwd(), prop.value);
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
   ],
   "homepage": "https://github.com/amznlabs/style-dictionary",
   "dependencies": {
-    "color": "^0.11.3",
     "commander": "^2.9.0",
     "fs-extra": "^0.30.0",
     "glob": "^7.1.1",
-    "lodash": "^4.16.4"
+    "lodash": "^4.16.4",
+    "tinycolor2": "^1.4.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -157,6 +157,13 @@ describe('transforms', function() {
       assert.equal(value, "#aaaaaa");
     });
 
+    it('should handle hex8 colors', function() {
+      var value = transforms["color/hex"].transformer({
+        value: "#aaaaaaaa"
+      });
+      assert.equal(value, "#aaaaaa");
+    });
+
     it('should handle rgb colors', function() {
       var value = transforms["color/hex"].transformer({
         value: "rgb(170,170,170)"
@@ -213,33 +220,29 @@ describe('transforms', function() {
 
     it('should handle rgb colors', function() {
       var value = transforms["color/hex8"].transformer({
-        value: {
-          r: '170',
-          g: '170',
-          b: '170'
-        }
-      });
-      var value2 = transforms["color/hex8"].transformer({
         value: "rgb(170,170,170)"
-      });
-      assert.equal(value, "#aaaaaaff");
-      assert.equal(value2, "#aaaaaaff");
-    });
-
-    it('should handle rgba (object) colors', function() {
-      var value = transforms["color/hex8"].transformer({
-        value: {
-          r: '170',
-          g: '170',
-          b: '170',
-          a: 0.6
-        }
       });
       var value2 = transforms["color/hex8"].transformer({
         value: "rgba(170,170,170,0.6)"
       });
-      assert.equal(value, "#aaaaaa99");
+      assert.equal(value, "#aaaaaaff");
       assert.equal(value2, "#aaaaaa99");
+    });
+  });
+
+  describe('color/hex8android', function() {
+    it('should handle colors without alpha', function() {
+      var value = transforms["color/hex8android"].transformer({
+        value: "#aaaaaa"
+      });
+      assert.equal(value, "#ffaaaaaa");
+    });
+
+    it('should handle colors with alpha', function() {
+      var value = transforms["color/hex8android"].transformer({
+        value: "#aaaaaa99"
+      });
+      assert.equal(value, "#99aaaaaa");
     });
   });
 

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -12,6 +12,7 @@
  */
 
 var assert     = require('chai').assert,
+    path       = require('path'),
     helpers    = require('./helpers'),
     transforms = require('../lib/common/transforms');
 
@@ -99,6 +100,322 @@ describe('transforms', function() {
         },{
         }
       ), 'ONE_TWO_THREE');
+    });
+  });
+
+  describe('name/ti/constant', function() {
+    it('should handle prefix', function() {
+      assert.equal(transforms["name/ti/constant"].transformer(
+        {
+          path: ['one','two','three']
+        },{
+          prefix: 'prefix'
+        }
+      ), 'PREFIX_TWO_THREE');
+    });
+
+    it('should handle no prefix', function() {
+      assert.equal(transforms["name/ti/constant"].transformer(
+        {
+          path: ['one','two','three']
+        },{
+        }
+      ), 'TWO_THREE');
+    });
+  });
+
+  describe('attribute/color', function() {
+    it('should handle normal colors', function() {
+      var attributes = transforms["attribute/color"].transformer({
+        value: "#aaaaaa"
+      });
+      assert.equal(attributes.rgb.a, 1);
+      assert.equal(attributes.rgb.r, 170);
+      assert.equal(attributes.hsl.s, 0);
+    });
+    it('should handle colors with transparency', function() {
+      var attributes = transforms["attribute/color"].transformer({
+        value: "#aaaaaa99"
+      });
+      var attributes2 = transforms["attribute/color"].transformer({
+        value: "rgba(170,170,170,0.6)"
+      });
+      assert.equal(attributes.rgb.a, 0.6);
+      assert.equal(attributes.rgb.r, 170);
+      assert.equal(attributes.hsl.s, 0);
+      assert.equal(attributes2.rgb.a, 0.6);
+      assert.equal(attributes2.rgb.r, 170);
+      assert.equal(attributes2.hsl.s, 0);
+    });
+  });
+
+  describe('color/hex', function() {
+    it('should handle hex colors', function() {
+      var value = transforms["color/hex"].transformer({
+        value: "#aaaaaa"
+      });
+      assert.equal(value, "#aaaaaa");
+    });
+
+    it('should handle rgb colors', function() {
+      var value = transforms["color/hex"].transformer({
+        value: "rgb(170,170,170)"
+      });
+      assert.equal(value, "#aaaaaa");
+    });
+
+    it('should handle rgb (object) colors', function() {
+      var value = transforms["color/hex"].transformer({
+        value: {
+          r: '170',
+          g: '170',
+          b: '170'
+        }
+      });
+      var value2 = transforms["color/hex"].transformer({
+        value: "rgb(170,170,170)"
+      });
+      assert.equal(value, "#aaaaaa");
+      assert.equal(value2, "#aaaaaa");
+    });
+
+    it('should handle hsl colors', function() {
+      var value = transforms["color/hex"].transformer({
+        value: {
+          h: '0',
+          s: '0',
+          l: '0.5'
+        }
+      });
+      var value2 = transforms["color/hex"].transformer({
+        value: "hsl(0,0,0.5)"
+      });
+      assert.equal(value, "#808080");
+      assert.equal(value2, "#808080");
+    });
+  });
+
+
+  describe('color/hex8', function() {
+    it('should handle hex colors', function() {
+      var value = transforms["color/hex8"].transformer({
+        value: "#aaaaaa"
+      });
+      assert.equal(value, "#aaaaaaff");
+    });
+
+    it('should handle rgb colors', function() {
+      var value = transforms["color/hex8"].transformer({
+        value: "rgb(170,170,170)"
+      });
+      assert.equal(value, "#aaaaaaff");
+    });
+
+    it('should handle rgb colors', function() {
+      var value = transforms["color/hex8"].transformer({
+        value: {
+          r: '170',
+          g: '170',
+          b: '170'
+        }
+      });
+      var value2 = transforms["color/hex8"].transformer({
+        value: "rgb(170,170,170)"
+      });
+      assert.equal(value, "#aaaaaaff");
+      assert.equal(value2, "#aaaaaaff");
+    });
+
+    it('should handle rgba (object) colors', function() {
+      var value = transforms["color/hex8"].transformer({
+        value: {
+          r: '170',
+          g: '170',
+          b: '170',
+          a: 0.6
+        }
+      });
+      var value2 = transforms["color/hex8"].transformer({
+        value: "rgba(170,170,170,0.6)"
+      });
+      assert.equal(value, "#aaaaaa99");
+      assert.equal(value2, "#aaaaaa99");
+    });
+  });
+
+  describe('color/rgb', function() {
+    it('should handle normal colors', function() {
+      var value = transforms["color/rgb"].transformer({
+        value: "#aaaaaa"
+      });
+      assert.equal(value, "rgb(170, 170, 170)");
+    });
+
+    it('should handle colors with transparency', function() {
+      var value = transforms["color/rgb"].transformer({
+        value: "#aaaaaa99"
+      });
+      assert.equal(value, "rgba(170, 170, 170, 0.6)");
+    });
+  });
+
+  describe('color/UIColor', function() {
+    it('should handle normal colors', function() {
+      var value = transforms["color/UIColor"].transformer({
+        value: "#aaaaaa"
+      });
+      assert.equal(value, "[UIColor colorWithRed:0.67f green:0.67f blue:0.67f alpha:1.00f]");
+    });
+
+    it('should handle colors with transparency', function() {
+      var value = transforms["color/UIColor"].transformer({
+        value: "#aaaaaa99"
+      });
+      assert.equal(value, "[UIColor colorWithRed:0.67f green:0.67f blue:0.67f alpha:0.60f]");
+    });
+  });
+
+
+  describe('size/sp', function() {
+    it('should work', function() {
+      var value = transforms["size/sp"].transformer({
+        value: "12px"
+      });
+      var value2 = transforms["size/sp"].transformer({
+        value: "12"
+      });
+      assert.equal(value, "12.00sp");
+      assert.equal(value2, "12.00sp");
+    });
+  });
+
+  describe('size/dp', function() {
+    it('should work', function() {
+      var value = transforms["size/dp"].transformer({
+        value: "12px"
+      });
+      var value2 = transforms["size/dp"].transformer({
+        value: "12"
+      });
+      assert.equal(value, "12.00dp");
+      assert.equal(value2, "12.00dp");
+    });
+  });
+
+  describe('size/remToSp', function() {
+    it('should work', function() {
+      var value = transforms["size/remToSp"].transformer({
+        value: "1"
+      });
+      assert.equal(value, "16.00sp");
+    });
+  });
+
+  describe('size/remToDp', function() {
+    it('should work', function() {
+      var value = transforms["size/remToDp"].transformer({
+        value: "1"
+      });
+      assert.equal(value, "16.00dp");
+    });
+  });
+
+  describe('size/px', function() {
+    it('should work', function() {
+      var value = transforms["size/px"].transformer({
+        value: "10"
+      });
+      assert.equal(value, "10px");
+    });
+  });
+
+  describe('size/remToPt', function() {
+    it('should work', function() {
+      var value = transforms["size/remToPt"].transformer({
+        value: "1"
+      });
+      assert.equal(value, "16.00f");
+    });
+  });
+
+  describe('size/remToPx', function() {
+    it('should work', function() {
+      var value = transforms["size/remToPx"].transformer({
+        value: "1"
+      });
+      assert.equal(value, "16px");
+    });
+  });
+
+  describe('size/rem', function() {
+    it('should work', function() {
+      var value = transforms["size/rem"].transformer({
+        value: "1"
+      });
+      assert.equal(value, "1rem");
+    });
+  });
+
+  describe('content/quote', function() {
+    it('should work', function() {
+      var value = transforms["content/quote"].transformer({
+        value: "hello"
+      });
+      assert.equal(value, "'hello'");
+    });
+  });
+
+  describe('content/icon', function() {
+    it('should work', function() {
+      var value = transforms["content/icon"].transformer({
+        value: "&#xE001;"
+      });
+      assert.equal(value, "'\\E001'");
+    });
+  });
+
+  describe('content/objC/literal', function() {
+    it('should work', function() {
+      var value = transforms["content/objC/literal"].transformer({
+        value: "hello"
+      });
+      assert.equal(value, '@"hello"');
+    });
+  });
+
+  describe('asset/objC/literal', function() {
+    it('should work', function() {
+      var value = transforms["asset/objC/literal"].transformer({
+        value: "hello"
+      });
+      assert.equal(value, '@"hello"');
+    });
+  });
+
+  describe('font/objC/literal', function() {
+    it('should work', function() {
+      var value = transforms["font/objC/literal"].transformer({
+        value: "hello"
+      });
+      assert.equal(value, '@"hello"');
+    });
+  });
+
+  describe('time/seconds', function() {
+    it('should work', function() {
+      var value = transforms["time/seconds"].transformer({
+        value: "1000"
+      });
+      assert.equal(value, "1.00s");
+    });
+  });
+
+  describe('asset/path', function() {
+    it('should work', function() {
+      var value = transforms["asset/path"].transformer({
+        value: "foo.json"
+      });
+      assert.equal(value, path.join(process.cwd(), "foo.json"));
     });
   });
 });


### PR DESCRIPTION
* Changed the color node module dependency to handle transparencies better.
* Added unit tests.
* Added new transforms to make use of transparencies
* Updated current transforms that could make use of transparencies
* Added transparent colors in the complete example for testing.
* Updated the transformGroups to use the new color transforms